### PR TITLE
Fix state name cannot contains underscore issue

### DIFF
--- a/example_project/Assets/MonsterLove/StateMachine/StateMachine.cs
+++ b/example_project/Assets/MonsterLove/StateMachine/StateMachine.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2016 Made With Monster Love (Pty) Ltd
+ * Copyright (c) 2016 Made With Mosnter Love (Pty) Ltd
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to 
@@ -102,10 +102,13 @@ namespace MonsterLove.StateMachine
 					continue;
 				}
 
+				var stateName = string.Join("_", names, 0, names.Length - 1);
+				var eventName = names[names.Length - 1];
+
 				Enum key;
 				try
 				{
-					key = (Enum) Enum.Parse(typeof(T), names[0]);
+					key = (Enum) Enum.Parse(typeof(T), stateName);
 				}
 				catch (ArgumentException)
 				{
@@ -115,7 +118,7 @@ namespace MonsterLove.StateMachine
 
 				var targetState = stateLookup[key];
 
-				switch (names[1])
+				switch(eventName)
 				{
 					case "Enter":
 						if (methods[i].ReturnType == typeof(IEnumerator))


### PR DESCRIPTION
Thank you for creating the plugin. It works well. 
I find the state name cannot contain underscores, otherwise the corresponding state-based function not get called, such as void MY_STATE_IDLE_FixedUpdate(). So I made some changes in the function-finding part, and it now splits the function name with the last underscore it finds.